### PR TITLE
Implements dual source video

### DIFF
--- a/assets/ts/index.ts
+++ b/assets/ts/index.ts
@@ -44,13 +44,36 @@ if (!!document.querySelectorAll('.hm-Hosted')) {
   })
 }
 
-window.getYoutubeIframe = function (event: Event, embedSrc: string) {
+const dualSourceVideo: HTMLVideoElement | null = document.querySelector('.hm-HostedVideo_Mobile');
+
+if (dualSourceVideo !== null) {
+  const { mobilesource, desktopsource} = dualSourceVideo.dataset;
+
+  const srcRegex = mobilesource ? new RegExp(mobilesource) : '';
+  const observer = new ResizeObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.contentBoxSize[0].inlineSize >= 1024) {
+        if (desktopsource && srcRegex && srcRegex.test(dualSourceVideo.src)) {
+          dualSourceVideo.src = `/${desktopsource}.mp4`;
+        }
+      } else {
+        if (mobilesource && srcRegex && !srcRegex.test(dualSourceVideo.src)) {
+          dualSourceVideo.src = `/${mobilesource}.mp4`
+        }
+      }
+    })
+  });
+  observer.observe(dualSourceVideo.closest('section')!);
+}
+
+
+window.getYoutubeIframe = function (event: KeyboardEvent, embedSrc: string) {
   event.preventDefault();
   event.stopPropagation();
   if (event.target && (event.type === "click" || (event.type === 'keydown' && event.keyCode === 13))) {
-    const container  = event.currentTarget.parentElement as HTMLElement;
-    const thumbnail = container.querySelector('img');
-    const playIcon = container.querySelector('svg');
+    const container  = (event.currentTarget as HTMLElement).parentElement!;
+    const thumbnail = container.querySelector('img')!;
+    const playIcon = container.querySelector('svg')!;
     thumbnail.style.pointerEvents = "none";
     playIcon.style.pointerEvents = "none";
     const containerDimentions = container.getBoundingClientRect();
@@ -63,7 +86,6 @@ window.getYoutubeIframe = function (event: Event, embedSrc: string) {
     el.setAttribute('autoplay', "true");
 
     thumbnail.style.position = "absolute";
-    el.addEventListener('DOMContentLoaded', () => console.log('iframe dom leaded'));
     el.addEventListener('load', () => {
       thumbnail.style.opacity = "0";
       playIcon.style.opacity = "0";

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,5 +5,5 @@ muted: 'muted'
 ---
 
 {{< section >}}
-        {{< hero_media "Overview-30s.mp4" muted >}}
+        {{< hero_media "Overview-30s.mp4" "Overview-30s-sq.mp4" muted >}}
 {{< /section >}}

--- a/layouts/shortcodes/hero_media.html
+++ b/layouts/shortcodes/hero_media.html
@@ -3,7 +3,7 @@
 {{ else }}
 
     {{- $input := .Get 0 -}}
-    {{- $muted := .Get 1 -}}
+    {{- $muted := cond (eq 3 (len .Params)) (.Get 2) (.Get 1) -}}
     {{ $res := .Page.Resources.GetMatch $input }}
 
     {{- if strings.Contains $input "iframe" }}
@@ -55,9 +55,14 @@
                     {{ readFile "static/icons/play-pause.svg" | safeHTML }}
                 </button>
             </div>
-            <video class="hm-HostedVideo" nocontrols autoplay loop webkit-playsinline="true" playisinline {{ $muted }} >
+            {{ if and (gt (len $.Params) 1) (strings.Contains ($.Get 1) ".mp4") }}
+            <video class="hm-HostedVideo hm-HostedVideo_Mobile" nocontrols autoplay loop webkit-playsinline="true" playisinline data-desktopsource="{{ strings.TrimRight ".mp4" $input }}" data-mobilesource="{{ strings.TrimRight ".mp4" ($.Get 1) }}" src="{{ $.Get 1 }}" type="video/mp4" {{ $muted }}>
+            </video>
+            {{ else }}
+            <video class="hm-HostedVideo" nocontrols autoplay loop webkit-playsinline="true" playisinline {{ $muted }}>
                 <source src="{{ $input }}" type="video/mp4">
             </video>
+            {{ end }}
         </div>
     {{ end -}}
 


### PR DESCRIPTION
Adds handling for mobile and desktop sources to the hero media shortcode, it is based on source ordering i.e.:

`{{< hero_media "Desktop_Video.mp4" "Mobile_Video.mp4" muted >}}`

Adding only two inputs *video* and *muted* is handled by checking if the second parameter has a **.mp4** file extension.