### PR TITLE
Adds an image shortcode

### DIFF
--- a/content/labs/_index.md
+++ b/content/labs/_index.md
@@ -15,6 +15,9 @@ layout: 'page'
 <img src="Otto.jpg" width="400" /><br>
 </p>
 
+{{< img art_direction="true" src="Otto.jpg" desktop="Otto.jpg" mobile="Workshop.jpg" loading="eager" width="500">}}
+{{< img src="Otto.jpg" width="500">}}
+
 Otto is the name for my live visuals system. Because it listens and responds as I play, it feels more like playing with another person than following along to a machine; hence giving Otto a name. Otto's listening system is built in [Max/MSP](https://cycling74.com/products/max) using modules from IRCAM's [Antescofo](https://forum.ircam.fr/projects/detail/antescofo) project.
 
 Otto is, if you're into specs, an AMD Ryzen 9 5900X 12-core 4.8GHz CPU and Nvidia 3060 GPU, on an Asus TUF Gaming X570-Plus WiFi motherboard. He's got Noctua fans so he's nice and quiet during performances. 

--- a/content/labs/_index.md
+++ b/content/labs/_index.md
@@ -15,9 +15,6 @@ layout: 'page'
 <img src="Otto.jpg" width="400" /><br>
 </p>
 
-{{< img art_direction="true" src="Otto.jpg" desktop="Otto.jpg" mobile="Workshop.jpg" loading="eager" width="500">}}
-{{< img src="Otto.jpg" width="500">}}
-
 Otto is the name for my live visuals system. Because it listens and responds as I play, it feels more like playing with another person than following along to a machine; hence giving Otto a name. Otto's listening system is built in [Max/MSP](https://cycling74.com/products/max) using modules from IRCAM's [Antescofo](https://forum.ircam.fr/projects/detail/antescofo) project.
 
 Otto is, if you're into specs, an AMD Ryzen 9 5900X 12-core 4.8GHz CPU and Nvidia 3060 GPU, on an Asus TUF Gaming X570-Plus WiFi motherboard. He's got Noctua fans so he's nice and quiet during performances. 

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,0 +1,16 @@
+{{ if and (ne nil (.Get "art_direction")) (or (eq .Params.art_direction "true") (eq .Params.art_direction true)) }}
+<picture>
+    <source media="(min-width: 1024px)" srcset="{{ .Get "desktop" }}" />
+    <img src="{{ .Get "mobile" }}" loading="{{ default "lazy" (.Get "loading") }}"
+        {{- with .Get "class" }} class="{{ . }}"{{ end -}}
+        {{- with .Get "style" }} style="{{ . }}"{{ end -}}
+        {{- with .Get "width" }} width="{{ . }}"{{ end -}}
+        {{- with .Get "height" }} height="{{ . }}"{{ end -}}>
+</picture> 
+{{ else }}
+<img src="{{ .Get "desktop" }}" loading="{{ default "lazy" (.Get "loading") }}"
+    {{- with .Get "class" }} class="{{ . }}"{{ end -}}
+    {{- with .Get "style" }} style="{{ . }}"{{ end -}}
+    {{- with .Get "width" }} width="{{ . }}"{{ end -}}
+    {{- with .Get "height" }} height="{{ . }}"{{ end -}}>
+{{ end }}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,16 +1,76 @@
 {{ if and (ne nil (.Get "art_direction")) (or (eq .Params.art_direction "true") (eq .Params.art_direction true)) }}
+{{- $mobile := .Page.Resources.Get (.Get "mobile") -}}
+{{- $desktop := .Page.Resources.Get (.Get "desktop") -}}
 <picture>
-    <source media="(min-width: 1024px)" srcset="{{ .Get "desktop" }}" />
-    <img src="{{ .Get "mobile" }}" loading="{{ default "lazy" (.Get "loading") }}"
+    <source media="(min-width: 1024px)" type="image/webp"
+        srcset="{{- if gt $desktop.Width 450 -}}{{ ($desktop.Resize `450x webp q80`).Permalink }} 450w,{{- end -}}
+        {{- if gt $desktop.Width 750 -}}{{ ($desktop.Resize `750x webp q80`).Permalink }} 750w,{{- end -}}
+        {{- if gt $desktop.Width 1100 -}}{{ ($desktop.Resize `1100x webp q80`).Permalink }} 1100w,{{- end -}}
+        {{- if gt $desktop.Width 1500 -}}{{ ($desktop.Resize `1500x webp q80`).Permalink }} 1500w,{{- end -}}
+        {{ ($desktop.Resize (printf `%dx%d webp q80` $desktop.Width $desktop.Height)).Permalink }} {{ $desktop.Width }}w"
+        sizes="{{- if (.Get "sizes") -}}
+                    {{- if eq (.Get "sizes") "content" -}}
+                    (max-width: 1023.99px): 100vw, 900px
+                    {{- else if eq (.Get "sizes") "full_width" -}}
+                    100vw
+                    {{- else -}}{{ .Get "sizes" }}{{- end -}}
+                {{- else -}}
+                    {{- with (.Get "width") -}}
+                    (max-width: 1023.99px): 100vw, {{ . }}px
+                    {{- else -}}
+                    100vw
+                    {{- end -}}
+                {{- end -}}" />
+    <img src="{{ $mobile.Permalink }}" loading="{{ default "lazy" (.Get "loading") }}"
         {{- with .Get "class" }} class="{{ . }}"{{ end -}}
         {{- with .Get "style" }} style="{{ . }}"{{ end -}}
         {{- with .Get "width" }} width="{{ . }}"{{ end -}}
-        {{- with .Get "height" }} height="{{ . }}"{{ end -}}>
+        {{- with .Get "height" }} height="{{ . }}"{{ end -}}
+        srcset="{{- if gt $mobile.Width 450 -}}{{ ($mobile.Resize `450x webp q80`).Permalink }} 450w,{{- end -}}
+        {{- if gt $mobile.Width 750 -}}{{ ($mobile.Resize `750x webp q80`).Permalink }} 750w,{{- end -}}
+        {{- if gt $mobile.Width 1100 -}}{{ ($mobile.Resize `1100x webp q80`).Permalink }} 1100w,{{- end -}}
+        {{- if gt $mobile.Width 1500 -}}{{ ($mobile.Resize `1500x webp q80`).Permalink }} 1500w,{{- end -}}
+        {{- if gt $mobile.Width 2000 -}}{{ ($mobile.Resize `2000x webp q80`).Permalink }} 2000w,{{- end -}}
+        {{ ($mobile.Resize (printf `%dx%d webp q80` $mobile.Width $mobile.Height)).Permalink }} {{ $mobile.Width }}w"
+        sizes="{{- if (.Get "sizes") -}}
+                    {{- if eq (.Get "sizes") "content" -}}
+                    (max-width: 1023.99px): 100vw, 900px
+                    {{- else if eq (.Get "sizes") "full_width" -}}
+                    100vw
+                    {{- else -}}{{ .Get "sizes" }}{{- end -}}
+                {{- else -}}
+                    {{- with (.Get "width") -}}
+                    (max-width: 1023.99px): 100vw, {{ . }}px
+                    {{- else -}}
+                    100vw
+                    {{- end -}}
+                {{- end -}}" />
 </picture> 
 {{ else }}
-<img src="{{ .Get "desktop" }}" loading="{{ default "lazy" (.Get "loading") }}"
+{{- $src := .Page.Resources.Get (.Get "src") -}} 
+<img src="{{ $src.Permalink }}" loading="{{ default "lazy" (.Get "loading") }}"
+    srcset="{{- if gt $src.Width 450 -}}{{ ($src.Resize `450x webp q80`).Permalink }} 450w,{{- end -}}
+    {{- if gt $src.Width 750 -}}{{ ($src.Resize `750x webp q80`).Permalink }} 750w,{{- end -}}
+    {{- if gt $src.Width 1100 -}}{{ ($src.Resize `1100x webp q80`).Permalink }} 1100w,{{- end -}}
+    {{- if gt $src.Width 1500 -}}{{ ($src.Resize `1500x webp q80`).Permalink }} 1500w,{{- end -}}
+    {{- if gt $src.Width 2000 -}}{{ ($src.Resize `2000x webp q80`).Permalink }} 2000w,{{- end -}}
+    {{ ($src.Resize (printf `%dx%d webp q80` $src.Width $src.Height)).Permalink }} {{ $src.Width }}w"
+    sizes="{{- if (.Get "sizes") -}}
+                {{- if eq (.Get "sizes") "content" -}}
+                (max-width: 1023.99px): 100vw, 900px
+                {{- else if eq (.Get "sizes") "full_width" -}}
+                100vw
+                {{- else -}}{{ .Get "sizes" }}{{- end -}}
+            {{- else -}}
+                {{- with (.Get "width") -}}
+                (max-width: 1023.99px): 100vw, {{ . }}px
+                {{- else -}}
+                100vw
+                {{- end -}}
+            {{- end -}}"
     {{- with .Get "class" }} class="{{ . }}"{{ end -}}
     {{- with .Get "style" }} style="{{ . }}"{{ end -}}
     {{- with .Get "width" }} width="{{ . }}"{{ end -}}
-    {{- with .Get "height" }} height="{{ . }}"{{ end -}}>
+    {{- with .Get "height" }} height="{{ . }}"{{ end -}}
+            />
 {{ end }}


### PR DESCRIPTION
Can be tested by placing in the labs page this snippet:

```
{{< img art_direction="true" src="Otto.jpg" desktop="Otto.jpg" mobile="Workshop.jpg" loading="eager" width="500">}}
{{< img src="Otto.jpg" width="400">}}
```
The shortcode has two variants, one with alternative sources for mobile and desktop, the other is a single source image, in both cases automatic image optimization is provided.
- The alternative sources variant needs to have the `mobile` and `desktop` parameters set to work properly
- The single source variant uses the `src` just like the standard <img> works

The following HTML attributes are accepted by the shortcode:
- width
- height
- class
- style

The  `sizes` parameter, helps the browser determine the most appropiate image version to download (resolution), it accepts two shorthand keywords or any value accepted by the standard sizes attribute, examples can be found here (https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes#examples). The shorthand values are:
- `content` which gives the browser a sizing hint with a max image with of 900px, this matches the default sizing for an image in a `{{< text_column >}}` shortcode.
- `full_width` is a shorthand for images spanning the full screen width or close to it.
In the absence of the `sizes` parameter the shortcode will check if `width` was set and construct a value using it or provide a fallback value if neither `sizes` or `width` can be found which will hint that the image will span the full screen width.